### PR TITLE
Add support for fullWidthCellRenderer and components

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+# EditorConfig is awesome: http://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+
+# 4 space indentation
+[**.*]
+indent_style = space
+indent_size = 4

--- a/src/agTemplate.ts
+++ b/src/agTemplate.ts
@@ -57,3 +57,15 @@ export class AgFilterTemplate {
         this.template = getTemplate(targetInstruction);
     }
 }
+
+@customElement('ag-full-width-row-template')
+@noView()
+@autoinject()
+@processContent(parseElement)
+export class AgFullWidthRowTemplate {
+    template: string;
+
+    constructor(targetInstruction: TargetInstruction) {
+        this.template = getTemplate(targetInstruction);
+    }
+}

--- a/src/aureliaComponentFactory.ts
+++ b/src/aureliaComponentFactory.ts
@@ -1,4 +1,8 @@
-import {autoinject, Container, transient, View, ViewFactory} from "aurelia-framework";
+import {
+    autoinject, Container, transient, View, ViewFactory,
+    CompositionEngine
+} from "aurelia-framework";
+
 
 import {ICellRenderer, ICellEditor} from "ag-grid/main";
 
@@ -7,14 +11,29 @@ import {IAureliaEditorViewModel} from "./editorViewModels";
 @autoinject()
 @transient()
 export class AureliaComponentFactory {
-    public createRendererFromTemplate(container: Container, viewFactory: ViewFactory): {new(): ICellRenderer} {
+
+    constructor(private compositionEngine: CompositionEngine) {
+
+    }
+
+    public createCellRendererFromViewFactory(container: Container, viewFactory: ViewFactory): {new(): ICellRenderer} {
         class CellRendererComponent implements ICellRenderer {
             private view: View;
+
+            private model:any;
 
             init(params: any) {
                 let bindingContext = {params: params};
                 this.view = viewFactory.create(container);
                 this.view.bind(bindingContext);
+                let controllers: any[] = (<any> this.view).controllers;
+
+                //only one controller is allowed in editor template
+                if (controllers && controllers.length){
+                    controllers.forEach((c) => {
+                        c.viewModel.params = params;
+                    })
+                }
             }
 
             getGui(): HTMLElement {
@@ -37,7 +56,6 @@ export class AureliaComponentFactory {
             private view: View;
             private editorVm: IAureliaEditorViewModel;
 
-
             init(params: any): void {
                 let bindingContext = {params: params};
                 this.view = viewFactory.create(container);
@@ -55,7 +73,8 @@ export class AureliaComponentFactory {
                     this.editorVm.params = params;
                 }
                 else {
-                    console.error('The editor template component is missing an IEditorViewModel or it contains more than one component');
+                    console.error(
+                        'The editor template component is missing an IEditorViewModel or it contains more than one component');
                 }
             }
 
@@ -79,18 +98,24 @@ export class AureliaComponentFactory {
             }
 
             isPopup(): boolean {
-                return this.editorVm.isPopup ?
-                    this.editorVm.isPopup() : false;
+                return this.editorVm.isPopup
+                    ?
+                       this.editorVm.isPopup()
+                    : false;
             }
 
             isCancelBeforeStart(): boolean {
-                return this.editorVm.isCancelBeforeStart ?
-                    this.editorVm.isCancelBeforeStart() : false;
+                return this.editorVm.isCancelBeforeStart
+                    ?
+                       this.editorVm.isCancelBeforeStart()
+                    : false;
             }
 
             isCancelAfterEnd(): boolean {
-                return this.editorVm.isCancelAfterEnd ?
-                    this.editorVm.isCancelAfterEnd() : false;
+                return this.editorVm.isCancelAfterEnd
+                    ?
+                       this.editorVm.isCancelAfterEnd()
+                    : false;
             }
 
             focusIn(): void {

--- a/src/aureliaFrameworkFactory.ts
+++ b/src/aureliaFrameworkFactory.ts
@@ -1,4 +1,8 @@
-import {autoinject, transient, Container, ViewResources, ViewCompiler} from "aurelia-framework";
+import {
+    autoinject, transient, Container, ViewResources, ViewCompiler,
+    ViewSlot, DOM, Origin, TemplatingEngine,
+    ViewFactory
+} from "aurelia-framework";
 
 import {
     ICellRenderer,
@@ -13,6 +17,12 @@ import {
 
 import {AureliaComponentFactory} from "./aureliaComponentFactory";
 
+export interface IAureliaRendererFramework {
+    component?: string|Function;
+    template?: string;
+    $viewFactory?: ViewFactory;
+}
+
 @autoinject()
 @transient()
 export class AureliaFrameworkFactory implements IFrameworkFactory {
@@ -20,39 +30,62 @@ export class AureliaFrameworkFactory implements IFrameworkFactory {
     private _viewResources: ViewResources;
     private _baseFrameworkFactory: IFrameworkFactory = new BaseFrameworkFactory();    // todo - inject this
 
-    constructor(private _componentFactory: AureliaComponentFactory, private _viewCompiler: ViewCompiler) {
+    constructor(private _componentFactory: AureliaComponentFactory,
+                private _viewCompiler: ViewCompiler,
+                private templatingEngine: TemplatingEngine) {
     }
 
     public colDefFloatingCellRenderer(colDef: ColDef): {new(): ICellRenderer} | ICellRendererFunc | string {
         return this._baseFrameworkFactory.colDefFloatingCellRenderer(colDef);
     }
 
+    public getCellRendererViewFactory(colDef: ColDef): Promise<void> {
+        return this.populateViewFactory(colDef.cellEditorFramework);
+    }
     public colDefCellRenderer(colDef: ColDef): {new(): ICellRenderer} | ICellRendererFunc | string {
-        if (colDef.cellRendererFramework) {
-            if (!colDef.cellRendererFramework.$viewFactory) {
-                colDef.cellRendererFramework.$viewFactory = this._viewCompiler.compile(colDef.cellRendererFramework.template, this._viewResources);
-            }
-
-            return this._componentFactory.createRendererFromTemplate(this._container, colDef.cellRendererFramework.$viewFactory);
-        } else {
+        let rendererFramework = colDef.cellRendererFramework;
+        //$viewFactory must be created before the grid is initialized
+        //because promises are involved.
+        if (rendererFramework && (rendererFramework.$viewFactory)) {
+            return this._componentFactory.createCellRendererFromViewFactory(this._container,
+                                                                            rendererFramework.$viewFactory);
+        }
+        else {
             return this._baseFrameworkFactory.colDefCellRenderer(colDef);
         }
     }
 
+    public getCellEditorViewFactory(colDef: ColDef): Promise<void> {
+        return this.populateViewFactory(colDef.cellEditorFramework);
+    }
     public colDefCellEditor(colDef: ColDef): {new(): ICellEditor} | string {
-        if (colDef.cellEditorFramework) {
-            //cache the columnDef viewFactory
-            if (!colDef.cellEditorFramework.$viewFactory) {
-                colDef.cellEditorFramework.$viewFactory = this._viewCompiler.compile(colDef.cellEditorFramework.template, this._viewResources);
-            }
-            return this._componentFactory.createEditorFromTemplate(this._container, colDef.cellEditorFramework.$viewFactory);
-
-        } else {
+        let rendererFramework = colDef.cellEditorFramework;
+        //$viewFactory must be created before the grid is initialized
+        //because promises are involved.
+        if (rendererFramework && (rendererFramework.$viewFactory)) {
+            return this._componentFactory.createEditorFromTemplate(this._container,
+                                                                   rendererFramework.$viewFactory);
+        }
+        else {
             return this._baseFrameworkFactory.colDefCellEditor(colDef);
         }
     }
 
+    public getFullWidthCellRendererViewFactory(gridOptions: GridOptions): Promise<void> {
+        return this.populateViewFactory(gridOptions.fullWidthCellRendererFramework);
+    }
+
     public gridOptionsFullWidthCellRenderer(gridOptions: GridOptions): {new(): ICellRenderer} | ICellRendererFunc | string {
+        let rendererFramework = gridOptions.fullWidthCellRendererFramework;
+
+        //$viewFactory must be created before the grid is initialized
+        //because promises are involved.
+        if (rendererFramework && (rendererFramework.$viewFactory)) {
+            return this._componentFactory
+                       .createCellRendererFromViewFactory(this._container, rendererFramework.$viewFactory);
+
+        }
+
         return this._baseFrameworkFactory.gridOptionsFullWidthCellRenderer(gridOptions);
     }
 
@@ -76,7 +109,59 @@ export class AureliaFrameworkFactory implements IFrameworkFactory {
         this._viewResources = viewResources;
     }
 
-    setTimeout(action: any, timeout?: any): void {
-        this._baseFrameworkFactory.setTimeout(action, timeout);
+    setTimeout(action: any, timeout?: any): number {
+        return this._baseFrameworkFactory.setTimeout(action, timeout);
     }
+
+    /**
+     * Aurelia returns a promise when creating a viewFactory for a component
+     */
+    private populateViewFactory(rendererFramework: IAureliaRendererFramework): Promise<void> {
+        if (!rendererFramework || (!rendererFramework.template && !rendererFramework.component)) {
+            return Promise.resolve();
+        }
+
+        if(rendererFramework.template && rendererFramework.component){
+            console.warn('Both template and component are present for the Aurelia renderer framework. Using Template');
+        }
+
+        if (rendererFramework.template) {
+            rendererFramework.$viewFactory = this._viewCompiler.compile(rendererFramework.template,
+                                                                        this._viewResources);
+            return Promise.resolve();
+        }
+
+        if (rendererFramework.component) {
+            return this.createViewFactoryFromComponent(rendererFramework.component)
+                .then(ViewFactory => {rendererFramework.$viewFactory = ViewFactory});
+        }
+
+    }
+
+    private createViewFactoryFromComponent(component: string | Function): Promise<ViewFactory> {
+        let host = DOM.createElement('div');
+
+        let viewModel = typeof component === 'function'
+            ? Origin.get(component).moduleId
+            : component;
+
+        let viewSlot = new ViewSlot(host, true);
+
+        let compositionContext = {
+            container: this._container,
+            viewModel: viewModel,
+            viewSlot: viewSlot,
+            viewResources: this._viewResources,
+            model: {}
+        };
+
+        return this.templatingEngine.compose(<any>compositionContext)
+                   .then((controller: any) => {
+                       //throw away the view we just compiled
+                       //we only want the view factory
+                       viewSlot.removeAll(true, true);
+                       return controller.view.viewFactory;
+                   });
+    }
+
 }


### PR DESCRIPTION
declarative:
```
           <ag-full-width-row-template>
              <span style="font-weight: bold">${params.data.name}</span>
            </ag-full-width-row-template>
```

 imperative:
```
  gridOptions.fullWidthCellRendererFramework = {template:NameAndAge};

 gridOptions.fullWidthCellRendererFramework =  {template:`<template><name-and-age></name-and-age></template>`};
```

Add support for Components.  To use:
```
   gridOptions.fullWidthCellRendererFramework = {component:NameAndAge};
   colDef.cellRendererFramework =  {component:NameAndAge};
```

 Any of the Framework properties can have either .template or .component populated