### PR TITLE
Fix: don't overwrite colDef.editable 

### DIFF
--- a/src/agGridColumn.ts
+++ b/src/agGridColumn.ts
@@ -49,7 +49,9 @@ export class AgGridColumn {
         }
 
         if (this.editorTemplate) {
-            colDef.editable = true;
+            if(colDef.editable === undefined) {
+                colDef.editable = true;
+            }
             colDef.cellEditorFramework = {template: this.editorTemplate.template};
             delete (<any>colDef).editorTemplate;
         }


### PR DESCRIPTION
colDef.editable was being overwritten when an editable template was defined.  This prevented the use of functions in colDef.editable.