### PR TITLE
fix(agGridColumn): default column definition not applying

### DIFF
--- a/src/agGridColumn.ts
+++ b/src/agGridColumn.ts
@@ -132,8 +132,10 @@ export class AgGridColumn {
     private createColDefFromGridColumn(): ColDef {
         let colDef: ColDef = {};
         for (let prop in this) {
-            let colDefProperty = this.mappedColumnProperties[prop] ? this.mappedColumnProperties[prop] : prop;
-            (<any>colDef)[colDefProperty] = (<any>this)[prop];
+            if (typeof (<any>this)[prop] !== "undefined") {
+                let colDefProperty = this.mappedColumnProperties[prop] ? this.mappedColumnProperties[prop] : prop;
+                (<any>colDef)[colDefProperty] = (<any>this)[prop];
+            }
         }
         delete (<any>colDef).childColumns;
         return colDef;

--- a/src/agGridColumn.ts
+++ b/src/agGridColumn.ts
@@ -80,21 +80,12 @@ export class AgGridColumn {
             }
         };
 
-        const editorAction = (templateName:string) => {
-            if (colDef.editable === undefined) {
-                colDef.editable = true;
-            }
-
-            defaultAction(templateName);
-        };
-
         const templates : any = {
             cellTemplate: {
                 frameworkName: 'cellRendererFramework'
             },
             editorTemplate: {
-                frameworkName: 'cellEditorFramework',
-                action: editorAction
+                frameworkName: 'cellEditorFramework'
             },
             filterTemplate: {
                 frameworkName: 'filterFramework'


### PR DESCRIPTION
Don't map column properties which are undefined. This prevents default column settings from being applied within the grid (because the property is present), and stops attributes like type from working. This pr Closes #24 